### PR TITLE
fix(package): default export should be last

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "amdName": "onlinepaymentssdk",
   "creator": "OnlinePayments",
   "exports": {
-    "default": "./dist/onlinepayments-sdk-client-js.js",
-    "types": "./dist/types/src/index.d.ts"
+    "types": "./dist/types/src/index.d.ts",
+    "default": "./dist/onlinepayments-sdk-client-js.js"
   },
   "types": "./dist/types/src/index.d.ts",
   "type": "module",


### PR DESCRIPTION
Fixing the error from webpack bundler 

```
Module not found: Error: Default condition should be last one
```

The build using webpack 5 is throwing an error when importing the library. 
Idk if this is thrown by babel, ts-loader or svelte loader but a rule seems to enforce that the default export is define last 